### PR TITLE
Bugfix for issue 787

### DIFF
--- a/tables/array/array30-big.head
+++ b/tables/array/array30-big.head
@@ -13,7 +13,7 @@ SERIAL_NUMBER = 2008A
 ICON = array30-big.png
 
 ### The default name of this table, this is needed
-NAME = Array30 Big Table
+NAME = Array30BigTable
 
 ### The local names of this table, this is optional
 NAME.zh_CN = 行列30大字集

--- a/tables/cangjie/cangjie3.txt
+++ b/tables/cangjie/cangjie3.txt
@@ -33,7 +33,7 @@ SERIAL_NUMBER = 2004111801
 ICON = cangjie3.svg
 
 ### The default name of this table
-NAME = CangJie 3
+NAME = CangJie3
 
 ### The local names of this table
 NAME.zh_CN = 仓颉第三代

--- a/tables/cangjie/cangjie5.txt
+++ b/tables/cangjie/cangjie5.txt
@@ -43,7 +43,7 @@ ICON = cangjie5.svg
 ### ICON = /usr/share/scim/icons/CangJie5.png
 
 ### The default name of this table
-NAME = CangJie 5
+NAME = CangJie5
 
 #### The local names of this table
 NAME.zh_CN = 仓颉第五代

--- a/tables/cantonese/cantonese.txt
+++ b/tables/cantonese/cantonese.txt
@@ -21,9 +21,9 @@ SERIAL_NUMBER = 20070429
 ICON = cantonese.png
 
 ### The default name of this table
-NAME = Cantonese Pinyin
+NAME = CantonesePinyin
 
-### The local names of this table 
+### The local names of this table
 NAME.zh_CN = 广东拼音
 NAME.zh_TW = 廣東拼音
 NAME.zh_HK = 廣東拼音

--- a/tables/cantonese/cantonhk.txt
+++ b/tables/cantonese/cantonhk.txt
@@ -25,12 +25,12 @@ UUID = c0de40f8-2861-433e-8b68-a80802415335
 ### This number must be less than 2^32.
 SERIAL_NUMBER = 2004112201
 
-ICON = cantonhk.png 
+ICON = cantonhk.png
 
 ### The default name of this table
-NAME = Canton HK
+NAME = CantonHK
 
-### The local names of this table 
+### The local names of this table
 NAME.zh_CN = 港式广东话
 NAME.zh_TW = 港式廣東話
 NAME.zh_HK = 港式廣東話

--- a/tables/easy/easy-big.txt
+++ b/tables/easy/easy-big.txt
@@ -1,5 +1,5 @@
 ### 版權聲明:
-###  
+###
 ### 本輸入法表格(輕鬆輸入法大型詞庫版) 乃根據《輕鬆資訊「輕鬆輸入法大詞庫」公眾授權書》的規定，
 ### 以 GPL V2.0 或更新的版本的規定所釋出，在遵守該許可證的規定下，
 ### 可以修改、複製及散佈本輸入法表格，唯本輸入法表格卻不包含任何擔保。
@@ -33,9 +33,9 @@ SERIAL_NUMBER = 20051122
 ICON = easy-big.png
 
 ### The default name of this table
-NAME = Easy Big
+NAME = EasyBig
 
-### The local names of this table 
+### The local names of this table
 NAME.zh_CN = 轻松大词库
 NAME.zh_HK = 輕鬆大詞庫
 NAME.zh_SG = 轻松大词库
@@ -130162,7 +130162,7 @@ END_TABLE
 ###+ core	Ｃｏｒｅｌ Ｄｒａｗ
 ###- ctrl	Ctrl 鍵
 ###+ ctrl	Ctrl 鍵
-###- c|	x	
+###- c|	x
 ###- d4t	標誌x
 ###+ d4t	標誌着
 ###- da(	
@@ -130368,7 +130368,7 @@ END_TABLE
 ###- kyu)	
 ###+ kyu(	きゅ
 ###+ kyu)	キュ
-###- l-	x	
+###- l-	x
 ###+ lgpl	GNU 較寬鬆公共授權
 ###- lot	LOTUS	1-2-3
 ###+ lot	LOTUS 1-2-3
@@ -130879,16 +130879,16 @@ END_TABLE
 ###- zz	
 ###- zz	
 ###- zz	
-###- zz	
-###- zz	
-###- zz	
-###- zz	
-###- zz	
-###- zz	
-###- zz	
-###- zz	
-###- zz	
-###- zz	
+###- zz
+###- zz
+###- zz
+###- zz
+###- zz
+###- zz
+###- zz
+###- zz
+###- zz
+###- zz
 ###+ zz	ⅰ
 ###+ zz	ⅱ
 ###+ zz	ⅲ

--- a/tables/quick/quick-classic.txt
+++ b/tables/quick/quick-classic.txt
@@ -21,9 +21,9 @@ SERIAL_NUMBER = 2004111801
 ICON = quick-classic.png
 
 ### The default name of this table
-NAME = Quick Classic
+NAME = QuickClassic
 
-### The local names of this table 
+### The local names of this table
 NAME.zh_CN = 速成古典版
 NAME.zh_TW = 速成古典版
 NAME.zh_HK = 速成古典版

--- a/tables/quick/quick3.txt
+++ b/tables/quick/quick3.txt
@@ -33,9 +33,9 @@ SERIAL_NUMBER = 2009021601
 ICON = quick3.png
 
 ### The default name of this table
-NAME = Quick 3
+NAME = Quick3
 
-### The local names of this table 
+### The local names of this table
 NAME.zh_CN = 速成第三代
 NAME.zh_TW = 速成第三代
 NAME.zh_HK = 速成第三代
@@ -50,7 +50,7 @@ LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 STATUS_PROMPT = CN
 
 ### If true then the phrases' frequencies will be adjusted dynamically.
-DYNAMIC_ADJUST = FALSE 
+DYNAMIC_ADJUST = FALSE
 
 ### Use full width punctuation by default
 DEF_FULL_WIDTH_PUNCT = TRUE

--- a/tables/quick/quick5.txt
+++ b/tables/quick/quick5.txt
@@ -30,7 +30,7 @@ BEGIN_DEFINITION
 
 ### An unique id to distinguish this table among others.
 ### Use uuidgen to generate this kind of id.
-UUID = 098d34b0-ea59-4957-baf0-c054ffffbf6a 
+UUID = 098d34b0-ea59-4957-baf0-c054ffffbf6a
 
 ### A unique number indicates the version of this file.
 ### For example the last modified date of this file.
@@ -41,9 +41,9 @@ ICON = quick5.png
 ### ICON = /usr/share/scim/icons/CangJie5.png
 
 ### The default name of this table
-NAME = Quick 5
+NAME = Quick5
 
-#### The local names of this table 
+#### The local names of this table
 NAME.zh_CN = 速成第五代
 NAME.zh_TW = 速成第五代
 NAME.zh_HK = 速成第五代
@@ -85,8 +85,8 @@ PINYIN_MODE = TRUE
 
 ### If true then the phrases' frequencies will be adjusted dynamically
 ### according your using frequency.
-DYNAMIC_ADJUST = FALSE 
- 
+DYNAMIC_ADJUST = FALSE
+
 ### Define the prompts of each valid input char.
 BEGIN_CHAR_PROMPTS_DEFINITION
 a 日

--- a/tables/scj/scj6.txt
+++ b/tables/scj/scj6.txt
@@ -31,7 +31,7 @@
 ### ===============================================================
 ### 輸入法發明人：朱邦復先生 http://www.cbflabs.com
 ### 碼表統一維護：倉頡之友.馬來西亞  http://www.chinesecj.com
-### 倉頡輸入版權：本輸入法無版權，歡迎大家復制使用及推廣倉頡。 
+### 倉頡輸入版權：本輸入法無版權，歡迎大家復制使用及推廣倉頡。
 ###
 ### ===============================================================
 ### 倉頡第三代
@@ -61,9 +61,9 @@ SERIAL_NUMBER = 20090505
 ICON = scj6.svg
 
 ### The default name of this table
-NAME = Smart CangJie 6
+NAME = SmartCangJie6
 
-### The local names of this table 
+### The local names of this table
 NAME.zh_CN = 快速仓颉第六代
 NAME.zh_TW = 快速倉頡第六代
 NAME.zh_HK = 快速倉頡第六代
@@ -90,7 +90,7 @@ AUTO_COMMIT = FALSE
 AUTO_SPLIT = TRUE
 
 ### If true then the phrases' frequencies will be adjusted dynamically.
-DYNAMIC_ADJUST = FALSE 
+DYNAMIC_ADJUST = FALSE
 
 ### If true then the preedit area will be filled up by the current candidate phrase automatically.
 AUTO_FILL = FALSE

--- a/tables/stroke5/stroke5.txt
+++ b/tables/stroke5/stroke5.txt
@@ -35,9 +35,9 @@ SERIAL_NUMBER = 2004112201
 ICON = stroke5.png
 
 ### The default name of this table
-NAME = Stroke 5
+NAME = Stroke5
 
-### The local names of this table 
+### The local names of this table
 NAME.zh_CN = 笔顺五码
 NAME.zh_TW = 筆順五碼
 NAME.zh_HK = 筆順五碼


### PR DESCRIPTION
- NAME attribute is used as a keyname for storing engine settings in
  GConf; however some of these table names contain spaces which violates
  GConf keyname restrictions
- see issue 787 (http://code.google.com/p/ibus/issues/detail?id=787) for
  details
