### PR TITLE
Give Cangjie and Quick users 9 candidates per page

### DIFF
--- a/tables/cangjie/cangjie3.txt
+++ b/tables/cangjie/cangjie3.txt
@@ -49,6 +49,9 @@ LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 ### Default value for the language filter
 LANGUAGE_FILTER = cm3
 
+### Keys to select candidates
+SELECT_KEYS = 1,2,3,4,5,6,7,8,9
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = CN
 

--- a/tables/cangjie/cangjie5.txt
+++ b/tables/cangjie/cangjie5.txt
@@ -56,6 +56,9 @@ LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 ### Default value for the language filter
 LANGUAGE_FILTER = cm3
 
+### Keys to select candidates
+SELECT_KEYS = 1,2,3,4,5,6,7,8,9
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = CN
 

--- a/tables/quick/quick3.txt
+++ b/tables/quick/quick3.txt
@@ -49,6 +49,9 @@ LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 ### Default value for the language filter
 LANGUAGE_FILTER = cm3
 
+### Keys to select candidates
+SELECT_KEYS = 1,2,3,4,5,6,7,8,9
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = CN
 

--- a/tables/quick/quick5.txt
+++ b/tables/quick/quick5.txt
@@ -54,6 +54,9 @@ LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 ### Default value for the language filter
 LANGUAGE_FILTER = cm3
 
+### Keys to select candidates
+SELECT_KEYS = 1,2,3,4,5,6,7,8,9
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = CN
 


### PR DESCRIPTION
Most users of these input methods really expect and want 9 candidates per
page.

Along with the default value of the ChineseMode filter (which was recently
fixed), this is the most common complaint/request from them.
