### PR TITLE
Add a default Chinese mode to all tables

### DIFF
--- a/tables/array/array30.head.in
+++ b/tables/array/array30.head.in
@@ -25,6 +25,16 @@ SERIAL_NUMBER = 20090101
 ### and "en_US, zh_CN" will be just ignored.
 LANGUAGES = zh_CN,zh_SG,zh_TW,zh_HK
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### The author of this table
 AUTHOR = 葉光哲, 廖明德
 

--- a/tables/cangjie/cangjie-big.txt
+++ b/tables/cangjie/cangjie-big.txt
@@ -33,7 +33,14 @@ NAME.zh_HK = 倉頡大字集
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
-### Default value for the language filter
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
 ### Prompt string to be displayed in the status area.

--- a/tables/cangjie/cangjie3.txt
+++ b/tables/cangjie/cangjie3.txt
@@ -46,7 +46,14 @@ AUTHOR = Roy Hiu-yeung Chan <roy.h.y.chan@gmail.com>
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
-### Default value for the language filter
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
 ### Keys to select candidates

--- a/tables/cangjie/cangjie5.txt
+++ b/tables/cangjie/cangjie5.txt
@@ -53,7 +53,14 @@ NAME.zh_HK = 倉頡第五代
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
-### Default value for the language filter
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
 ### Keys to select candidates

--- a/tables/cantonese/cantonese.txt
+++ b/tables/cantonese/cantonese.txt
@@ -34,6 +34,16 @@ NAME.zh_HK = 廣東拼音
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = 中
 

--- a/tables/cantonese/cantonhk.txt
+++ b/tables/cantonese/cantonhk.txt
@@ -41,6 +41,16 @@ NAME.zh_HK = 港式廣東話
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = 中
 

--- a/tables/easy/easy-big.txt
+++ b/tables/easy/easy-big.txt
@@ -47,6 +47,16 @@ NAME.zh_TW = 輕鬆大詞庫
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### The author of this table
 AUTHOR = Woodman Tuen <wmtuen@gmail.com>
 

--- a/tables/erbi/erbi.txt
+++ b/tables/erbi/erbi.txt
@@ -34,6 +34,16 @@ NAME.zh_HK = 二筆-小林子
 ### Supported languages of this table
 LANGUAGES = zh_CN,zh_SG,zh_TW,zh_HK
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm2
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = 中
 

--- a/tables/quick/quick-classic.txt
+++ b/tables/quick/quick-classic.txt
@@ -34,7 +34,14 @@ NAME.zh_HK = 速成古典版
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
-### Default value for the language filter
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
 ### The author of this table

--- a/tables/quick/quick3.txt
+++ b/tables/quick/quick3.txt
@@ -49,7 +49,14 @@ AUTHOR = Roy Hiu-yeung Chan <roy.h.y.chan@gmail.com>
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
-### Default value for the language filter
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
 ### Keys to select candidates

--- a/tables/quick/quick5.txt
+++ b/tables/quick/quick5.txt
@@ -54,7 +54,14 @@ NAME.zh_HK = 速成第五代
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
-### Default value for the language filter
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
 ### Keys to select candidates

--- a/tables/scj/scj6.txt
+++ b/tables/scj/scj6.txt
@@ -74,6 +74,16 @@ NAME.zh_HK = 快速倉頡第六代
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = CN
 

--- a/tables/stroke5/stroke5.txt
+++ b/tables/stroke5/stroke5.txt
@@ -48,6 +48,16 @@ NAME.zh_HK = 筆順五碼
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = 中
 

--- a/tables/wu/wu.txt
+++ b/tables/wu/wu.txt
@@ -35,6 +35,16 @@ NAME.zh_HK = 吳語注音法
 ### Supported languages of this table
 LANGUAGES = zh_HK,zh_CN,zh_TW,zh_SG
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = 中
 

--- a/tables/wubi-haifeng/wubi-haifeng86.head
+++ b/tables/wubi-haifeng/wubi-haifeng86.head
@@ -39,6 +39,16 @@ NAME.zh_HK = 海峰五筆86
 ### Supported languages of this table
 LANGUAGES = zh_CN,zh_SG,zh_TW,zh_HK
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm2
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = CN
 

--- a/tables/wubi-jidian/wubi-jidian86.txt
+++ b/tables/wubi-jidian/wubi-jidian86.txt
@@ -44,6 +44,16 @@ NAME.zh_HK = 極點五筆 86（極爽詞庫 6.0）
 ### Supported languages of this table
 LANGUAGES = zh_CN,zh_SG,zh_TW,zh_HK
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm2
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = CN
 

--- a/tables/yong/yong.txt
+++ b/tables/yong/yong.txt
@@ -32,6 +32,16 @@ NAME.zh_HK = 永碼
 ### Supported languages of this table
 LANGUAGES = zh_CN,zh_TW,zh_HK
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm2
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = CN
 

--- a/tables/zhuyin-big.txt
+++ b/tables/zhuyin-big.txt
@@ -30,6 +30,16 @@ NAME.zh_TW = 注音大字集
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### The author of this table
 ### AUTHOR = 
 

--- a/tables/zhuyin.txt
+++ b/tables/zhuyin.txt
@@ -42,6 +42,16 @@ DESCRIPTION = Zhyin (BoPoMoFo) Chinese input method.
 ### and "en_US, zh_CN" will be just ignored.
 LANGUAGES = zh_CN,zh_SG,zh_TW,zh_HK
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### The author of this table
 AUTHOR = Ding-Yi Chen <dingyichentw@yahoo.com>
 


### PR DESCRIPTION
ibus-table uses the following priority to select the Chinese mode:

1) User setting (can be set in the setup tool or the property menu)
2) The value of LANGUAGE_FILTER in the table source
3) The locale

Getting the default for the Chinese mode from the locale is only a
last ditch guess. A user who wants to use a table for traditional
Chinese does not necessarily run his system in a traditional Chinese
locale.  It is better if each table already specifies a default
suitable for that table.
