### PR TITLE
Use nicer values for symbol and status prompt

### DIFF
--- a/tables/array/array30.head.in
+++ b/tables/array/array30.head.in
@@ -38,9 +38,11 @@ LANGUAGE_FILTER = cm3
 ### The author of this table
 AUTHOR = 葉光哲, 廖明德
 
-### Prompt string to be displayed in the status area, CN will be replaced by
-### the gettext tools in runtime as 中.
-STATUS_PROMPT = CN
+### The symbol to be displayed in IM switchers
+SYMBOL = 行列
+
+### Prompt string to be displayed in the status area.
+STATUS_PROMPT = 行列
 
 ### Valid input chars.
 VALID_INPUT_CHARS = abcdefghijklmnopqrstuvwxyz./;,

--- a/tables/array/array30.head.in
+++ b/tables/array/array30.head.in
@@ -25,6 +25,16 @@ SERIAL_NUMBER = 20090101
 ### and "en_US, zh_CN" will be just ignored.
 LANGUAGES = zh_CN,zh_SG,zh_TW,zh_HK
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### The author of this table
 AUTHOR = 葉光哲, 廖明德
 

--- a/tables/cangjie/cangjie-big.txt
+++ b/tables/cangjie/cangjie-big.txt
@@ -43,8 +43,11 @@ LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 ### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 倉
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = 中
+STATUS_PROMPT = 倉
 
 ### The Keyboard Layout used by this table. Unset or set to "Unknown" to accept any kind of layouts.
 KEYBOARD_LAYOUT = US_Default

--- a/tables/cangjie/cangjie-big.txt
+++ b/tables/cangjie/cangjie-big.txt
@@ -33,7 +33,14 @@ NAME.zh_HK = 倉頡大字集
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
-### Default value for the language filter
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
 ### Prompt string to be displayed in the status area.

--- a/tables/cangjie/cangjie3.txt
+++ b/tables/cangjie/cangjie3.txt
@@ -59,8 +59,11 @@ LANGUAGE_FILTER = cm3
 ### Keys to select candidates
 SELECT_KEYS = 1,2,3,4,5,6,7,8,9
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 倉㈢
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = CN
+STATUS_PROMPT = 倉㈢
 
 ### If true then the phrases' frequencies will be adjusted dynamically.
 DYNAMIC_ADJUST = TRUE

--- a/tables/cangjie/cangjie3.txt
+++ b/tables/cangjie/cangjie3.txt
@@ -46,7 +46,14 @@ AUTHOR = Roy Hiu-yeung Chan <roy.h.y.chan@gmail.com>
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
-### Default value for the language filter
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
 ### Keys to select candidates

--- a/tables/cangjie/cangjie5.txt
+++ b/tables/cangjie/cangjie5.txt
@@ -66,8 +66,11 @@ LANGUAGE_FILTER = cm3
 ### Keys to select candidates
 SELECT_KEYS = 1,2,3,4,5,6,7,8,9
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 倉㈤
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = CN
+STATUS_PROMPT = 倉㈤
 
 ### Use full width punctuation by default
 DEF_FULL_WIDTH_PUNCT = TRUE

--- a/tables/cangjie/cangjie5.txt
+++ b/tables/cangjie/cangjie5.txt
@@ -53,7 +53,14 @@ NAME.zh_HK = 倉頡第五代
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
-### Default value for the language filter
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
 ### Keys to select candidates

--- a/tables/cantonese/cantonese.txt
+++ b/tables/cantonese/cantonese.txt
@@ -44,8 +44,11 @@ LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 ### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 廣
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = 中
+STATUS_PROMPT = 廣
 
 ### If true then the first candidate phrase
 ### will be selected automatically during inputing.

--- a/tables/cantonese/cantonese.txt
+++ b/tables/cantonese/cantonese.txt
@@ -34,6 +34,16 @@ NAME.zh_HK = 廣東拼音
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = 中
 

--- a/tables/cantonese/cantonhk.txt
+++ b/tables/cantonese/cantonhk.txt
@@ -41,6 +41,16 @@ NAME.zh_HK = 港式廣東話
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = 中
 

--- a/tables/cantonese/cantonhk.txt
+++ b/tables/cantonese/cantonhk.txt
@@ -51,8 +51,11 @@ LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 ### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 港廣
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = 中
+STATUS_PROMPT = 港廣
 
 ### If true then the first candidate phrase
 ### will be selected automatically during inputing.

--- a/tables/easy/easy-big.txt
+++ b/tables/easy/easy-big.txt
@@ -60,8 +60,11 @@ LANGUAGE_FILTER = cm3
 ### The author of this table
 AUTHOR = Woodman Tuen <wmtuen@gmail.com>
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 輕
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = 中
+STATUS_PROMPT = 輕
 
 ### The Keyboard Layout used by this table. Unset or set to "Unknown" to accept any kind of layouts.
 KEYBOARD_LAYOUT = US_Default

--- a/tables/easy/easy-big.txt
+++ b/tables/easy/easy-big.txt
@@ -47,6 +47,16 @@ NAME.zh_TW = 輕鬆大詞庫
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### The author of this table
 AUTHOR = Woodman Tuen <wmtuen@gmail.com>
 

--- a/tables/erbi/erbi-qs.txt
+++ b/tables/erbi/erbi-qs.txt
@@ -37,8 +37,11 @@ LANGUAGES = zh_CN,zh_SG,zh_TW,zh_HK
 ### The author of this table
 AUTHOR = npwjm <npwjm@163.com>
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 青
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = CN
+STATUS_PROMPT = 青
 
 ### Use full width punctuation by default
 DEF_FULL_WIDTH_PUNCT = TRUE

--- a/tables/erbi/erbi.txt
+++ b/tables/erbi/erbi.txt
@@ -44,8 +44,11 @@ LANGUAGES = zh_CN,zh_SG,zh_TW,zh_HK
 ### cm4 means to show all characters
 LANGUAGE_FILTER = cm2
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 贰
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = 中
+STATUS_PROMPT = 贰
 
 ### The Keyboard Layout used by this table. Unset or set to "Unknown" to accept any kind of layouts.
 KEYBOARD_LAYOUT = US_Default

--- a/tables/erbi/erbi.txt
+++ b/tables/erbi/erbi.txt
@@ -34,6 +34,16 @@ NAME.zh_HK = 二筆-小林子
 ### Supported languages of this table
 LANGUAGES = zh_CN,zh_SG,zh_TW,zh_HK
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm2
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = 中
 

--- a/tables/quick/quick-classic.txt
+++ b/tables/quick/quick-classic.txt
@@ -47,8 +47,11 @@ LANGUAGE_FILTER = cm3
 ### The author of this table
 AUTHOR = Roy Hiu-yeung Chan <roy.h.y.chan@gmail.com>
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 速
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = 中
+STATUS_PROMPT = 速
 
 ### The Keyboard Layout used by this table. Unset or set to "Unknown" to accept any kind of layouts.
 KEYBOARD_LAYOUT = US_Default

--- a/tables/quick/quick-classic.txt
+++ b/tables/quick/quick-classic.txt
@@ -34,7 +34,14 @@ NAME.zh_HK = 速成古典版
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
-### Default value for the language filter
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
 ### The author of this table

--- a/tables/quick/quick3.txt
+++ b/tables/quick/quick3.txt
@@ -62,8 +62,11 @@ LANGUAGE_FILTER = cm3
 ### Keys to select candidates
 SELECT_KEYS = 1,2,3,4,5,6,7,8,9
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 速㈢
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = CN
+STATUS_PROMPT = 速㈢
 
 ### If true then the phrases' frequencies will be adjusted dynamically.
 DYNAMIC_ADJUST = FALSE

--- a/tables/quick/quick3.txt
+++ b/tables/quick/quick3.txt
@@ -49,7 +49,14 @@ AUTHOR = Roy Hiu-yeung Chan <roy.h.y.chan@gmail.com>
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
-### Default value for the language filter
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
 ### Keys to select candidates

--- a/tables/quick/quick5.txt
+++ b/tables/quick/quick5.txt
@@ -54,7 +54,14 @@ NAME.zh_HK = 速成第五代
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
-### Default value for the language filter
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
 ### Keys to select candidates

--- a/tables/quick/quick5.txt
+++ b/tables/quick/quick5.txt
@@ -67,8 +67,11 @@ LANGUAGE_FILTER = cm3
 ### Keys to select candidates
 SELECT_KEYS = 1,2,3,4,5,6,7,8,9
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 速㈤
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = CN
+STATUS_PROMPT = 速㈤
 
 ### If true then the phrases' frequencies will be adjusted dynamically.
 DYNAMIC_ADJUST = FALSE

--- a/tables/scj/scj6.txt
+++ b/tables/scj/scj6.txt
@@ -74,6 +74,16 @@ NAME.zh_HK = 快速倉頡第六代
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = CN
 

--- a/tables/scj/scj6.txt
+++ b/tables/scj/scj6.txt
@@ -84,8 +84,11 @@ LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 ### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 快倉
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = CN
+STATUS_PROMPT = 快倉
 
 ### If true then the first candidate phrase
 ### will be selected automatically during inputing.

--- a/tables/stroke5/stroke5.txt
+++ b/tables/stroke5/stroke5.txt
@@ -48,6 +48,16 @@ NAME.zh_HK = 筆順五碼
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = 中
 

--- a/tables/stroke5/stroke5.txt
+++ b/tables/stroke5/stroke5.txt
@@ -58,8 +58,11 @@ LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 ### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 筆㈤
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = 中
+STATUS_PROMPT = 筆㈤
 
 ### The Keyboard Layout used by this table. Unset or set to "Unknown" to accept any kind of layouts.
 KEYBOARD_LAYOUT = US_Default

--- a/tables/wu/wu.txt
+++ b/tables/wu/wu.txt
@@ -35,6 +35,16 @@ NAME.zh_HK = 吳語注音法
 ### Supported languages of this table
 LANGUAGES = zh_HK,zh_CN,zh_TW,zh_SG
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = 中
 

--- a/tables/wu/wu.txt
+++ b/tables/wu/wu.txt
@@ -45,8 +45,11 @@ LANGUAGES = zh_HK,zh_CN,zh_TW,zh_SG
 ### cm4 means to show all characters
 LANGUAGE_FILTER = cm3
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 吳
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = 中
+STATUS_PROMPT = 吳
 
 ### If true then the first candidate phrase
 ### will be selected automatically during inputing.

--- a/tables/wubi-haifeng/wubi-haifeng86.head
+++ b/tables/wubi-haifeng/wubi-haifeng86.head
@@ -39,6 +39,16 @@ NAME.zh_HK = 海峰五筆86
 ### Supported languages of this table
 LANGUAGES = zh_CN,zh_SG,zh_TW,zh_HK
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm2
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = CN
 

--- a/tables/wubi-haifeng/wubi-haifeng86.head
+++ b/tables/wubi-haifeng/wubi-haifeng86.head
@@ -49,8 +49,11 @@ LANGUAGES = zh_CN,zh_SG,zh_TW,zh_HK
 ### cm4 means to show all characters
 LANGUAGE_FILTER = cm2
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 海
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = CN
+STATUS_PROMPT = 海
 
 ### Use full width punctuation by default
 DEF_FULL_WIDTH_PUNCT = TRUE

--- a/tables/wubi-jidian/wubi-jidian86.txt
+++ b/tables/wubi-jidian/wubi-jidian86.txt
@@ -44,6 +44,16 @@ NAME.zh_HK = 極點五筆 86（極爽詞庫 6.0）
 ### Supported languages of this table
 LANGUAGES = zh_CN,zh_SG,zh_TW,zh_HK
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm2
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = CN
 

--- a/tables/wubi-jidian/wubi-jidian86.txt
+++ b/tables/wubi-jidian/wubi-jidian86.txt
@@ -54,8 +54,11 @@ LANGUAGES = zh_CN,zh_SG,zh_TW,zh_HK
 ### cm4 means to show all characters
 LANGUAGE_FILTER = cm2
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 五
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = CN
+STATUS_PROMPT = 五
 
 ### Use full width punctuation by default
 DEF_FULL_WIDTH_PUNCT = TRUE

--- a/tables/yong/yong.txt
+++ b/tables/yong/yong.txt
@@ -32,6 +32,16 @@ NAME.zh_HK = 永碼
 ### Supported languages of this table
 LANGUAGES = zh_CN,zh_TW,zh_HK
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm2
+
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = CN
 

--- a/tables/yong/yong.txt
+++ b/tables/yong/yong.txt
@@ -42,8 +42,11 @@ LANGUAGES = zh_CN,zh_TW,zh_HK
 ### cm4 means to show all characters
 LANGUAGE_FILTER = cm2
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 永碼
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = CN
+STATUS_PROMPT = 永碼
 
 ### Use full width punctuation by default
 DEF_FULL_WIDTH_PUNCT = TRUE

--- a/tables/zhuyin-big.txt
+++ b/tables/zhuyin-big.txt
@@ -43,8 +43,11 @@ LANGUAGE_FILTER = cm3
 ### The author of this table
 ### AUTHOR = 
 
+### The symbol to be displayed in IM switchers
+SYMBOL = 注大
+
 ### Prompt string to be displayed in the status area.
-STATUS_PROMPT = 中
+STATUS_PROMPT = 注大
 
 ### The Keyboard Layout used by this table. Unset or set to "Unknown" to accept any kind of layouts.
 KEYBOARD_LAYOUT = US_Default

--- a/tables/zhuyin-big.txt
+++ b/tables/zhuyin-big.txt
@@ -30,6 +30,16 @@ NAME.zh_TW = 注音大字集
 ### Supported languages of this table
 LANGUAGES = zh_TW,zh_HK,zh_CN,zh_SG
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### The author of this table
 ### AUTHOR = 
 

--- a/tables/zhuyin.txt
+++ b/tables/zhuyin.txt
@@ -55,9 +55,11 @@ LANGUAGE_FILTER = cm3
 ### The author of this table
 AUTHOR = Ding-Yi Chen <dingyichentw@yahoo.com>
 
-### Prompt string to be displayed in the status area, CN will be replaced by
-### the gettext tools in runtime as 中.
-STATUS_PROMPT = CN
+### The symbol to be displayed in IM switchers
+SYMBOL = 注
+
+### Prompt string to be displayed in the status area.
+STATUS_PROMPT = 注
 
 ### Layout
 LAYOUT = us

--- a/tables/zhuyin.txt
+++ b/tables/zhuyin.txt
@@ -42,6 +42,16 @@ DESCRIPTION = Zhyin (BoPoMoFo) Chinese input method.
 ### and "en_US, zh_CN" will be just ignored.
 LANGUAGES = zh_CN,zh_SG,zh_TW,zh_HK
 
+### Default value for the language filter.
+### Only important for Chinese, it can be set to “cm<number>” where
+### <number> can be in the range from 0 to 4. “cm” means “Chinese mode”.
+### cm0 means to show simplified Chinese only
+### cm1 means to show traditional Chinese only
+### cm2 means to show all characters but show simplified Chinese first
+### cm3 means to show all characters but show traditional Chinese first
+### cm4 means to show all characters
+LANGUAGE_FILTER = cm3
+
 ### The author of this table
 AUTHOR = Ding-Yi Chen <dingyichentw@yahoo.com>
 


### PR DESCRIPTION
```
Use nicer values for SYMBOL and STATUS_PROMPT in all tables

- This is to have something nicer displayed in the on-screen-display
  for input method switching in Gnome3, not only zh₁, zh₂, …

- make it agree mostly with the look of the icons
```
