### PR TITLE
Add SUGGESTION_MODE = TRUE to the wubi tables

### DIFF
--- a/tables/wubi-haifeng/wubi-haifeng86.head
+++ b/tables/wubi-haifeng/wubi-haifeng86.head
@@ -73,6 +73,9 @@ USER_CAN_DEFINE_PHRASE = TRUE
 ### Whether support PinYin Mode, default is true
 PINYIN_MODE = TRUE
 
+### Whether to support suggestion mode, default is false
+SUGGESTION_MODE = TRUE
+
 ### If true then the phrases' frequencies will be adjusted dynamically.
 DYNAMIC_ADJUST = TRUE
 

--- a/tables/wubi-jidian/wubi-jidian86.txt
+++ b/tables/wubi-jidian/wubi-jidian86.txt
@@ -78,6 +78,9 @@ USER_CAN_DEFINE_PHRASE = TRUE
 ### Whether support PinYin Mode, default is true
 PINYIN_MODE = TRUE
 
+### Whether to support suggestion mode, default is false
+SUGGESTION_MODE = TRUE
+
 ### If true then the phrases' frequencies will be adjusted dynamically.
 DYNAMIC_ADJUST = TRUE
 


### PR DESCRIPTION
Recently suggestion mode has been added to ibus-table by Peng Wu.
See:

https://github.com/mike-fabian/ibus-table/releases/tag/1.10.0
https://github.com/mike-fabian/ibus-table/pull/9
https://bugzilla.redhat.com/show_bug.cgi?id=835376

It is necessary to add “SUGGESTION_MODE = TRUE” to the tables
for which suggestion mode should be available.